### PR TITLE
Add more statistics to simulation reports

### DIFF
--- a/auctionrunner/fake_auctionrunner/fake_auctionrunner.go
+++ b/auctionrunner/fake_auctionrunner/fake_auctionrunner.go
@@ -2,8 +2,8 @@
 package fake_auctionrunner
 
 import (
-	"sync"
 	. "github.com/cloudfoundry-incubator/auction/auctiontypes"
+	"sync"
 )
 
 type FakeAuctionRunner struct {

--- a/communication/nats/nats_muxer/nats_muxer_test.go
+++ b/communication/nats/nats_muxer/nats_muxer_test.go
@@ -2,10 +2,10 @@ package nats_muxer_test
 
 import (
 	"fmt"
+	. "github.com/cloudfoundry-incubator/auction/communication/nats/nats_muxer"
 	"strconv"
 	"sync"
 	"time"
-	. "github.com/cloudfoundry-incubator/auction/communication/nats/nats_muxer"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/simulation/auctiondistributor/auction_distributor.go
+++ b/simulation/auctiondistributor/auction_distributor.go
@@ -44,8 +44,14 @@ func NewRemoteAuctionDistributor(hosts []string, client auctiontypes.SimulationR
 	}
 }
 
-func (ad *AuctionDistributor) HoldAuctionsFor(instances []models.LRPStartAuction, representatives []string, rules auctiontypes.StartAuctionRules) *visualization.Report {
-	fmt.Printf("\nStarting Auctions\n\n")
+func (ad *AuctionDistributor) HoldAuctionsFor(
+	scenarioDescription string,
+	numRepresentatives int,
+	instances []models.LRPStartAuction,
+	representatives []string,
+	rules auctiontypes.StartAuctionRules,
+) *visualization.Report {
+	fmt.Printf("\nStarting Auctions: '%s' on %d Executors\n\n", scenarioDescription, numRepresentatives)
 	bar := pb.StartNew(len(instances))
 
 	t := time.Now()

--- a/simulation/simulation_test.go
+++ b/simulation/simulation_test.go
@@ -109,10 +109,14 @@ var _ = Describe("Auction", func() {
 						instances = append(instances, generateUniqueLRPStartAuctions(n4apps[i]/2, 4)...)
 						instances = append(instances, generateLRPStartAuctionsWithRandomSVGColors(n4apps[i]/2, 4)...)
 
+						permutedInstances := make([]models.LRPStartAuction, len(instances))
+						for i, index := range util.R.Perm(len(instances)) {
+							permutedInstances[i] = instances[index]
+						}
 						report := auctionDistributor.HoldAuctionsFor(
 							"Cold start with single-instance and multi-instance apps",
 							nexec[i],
-							instances,
+							permutedInstances,
 							repGuids[:nexec[i]],
 							auctionrunner.DefaultStartAuctionRules,
 						)

--- a/simulation/simulation_test.go
+++ b/simulation/simulation_test.go
@@ -98,7 +98,7 @@ var _ = Describe("Auction", func() {
 			n4apps := []int{50, 200}
 			for i := range nexec {
 				i := i
-				Context("with single-instance and multi-instance apps", func() {
+				Context("with variable memory requirements between apps", func() {
 					It("should distribute evenly", func() {
 						instances := []models.LRPStartAuction{}
 
@@ -114,7 +114,7 @@ var _ = Describe("Auction", func() {
 							permutedInstances[i] = instances[index]
 						}
 						report := auctionDistributor.HoldAuctionsFor(
-							"Cold start with single-instance and multi-instance apps",
+							"Cold start with variable memory requirements between apps",
 							nexec[i],
 							permutedInstances,
 							repGuids[:nexec[i]],
@@ -134,7 +134,6 @@ var _ = Describe("Auction", func() {
 					})
 				})
 			}
-
 		})
 
 		Context("Imbalanced scenario (e.g. a deploy)", func() {

--- a/simulation/simulation_test.go
+++ b/simulation/simulation_test.go
@@ -109,9 +109,21 @@ var _ = Describe("Auction", func() {
 						instances = append(instances, generateUniqueLRPStartAuctions(n4apps[i]/2, 4)...)
 						instances = append(instances, generateLRPStartAuctionsWithRandomSVGColors(n4apps[i]/2, 4)...)
 
-						report := auctionDistributor.HoldAuctionsFor(instances, repGuids[:nexec[i]], auctionrunner.DefaultStartAuctionRules)
+						report := auctionDistributor.HoldAuctionsFor(
+							"Cold start with single-instance and multi-instance apps",
+							nexec[i],
+							instances,
+							repGuids[:nexec[i]],
+							auctionrunner.DefaultStartAuctionRules,
+						)
 
-						visualization.PrintReport(client, report.AuctionResults, repGuids[:nexec[i]], report.AuctionDuration, auctionrunner.DefaultStartAuctionRules)
+						visualization.PrintReport(
+							client,
+							report.AuctionResults,
+							repGuids[:nexec[i]],
+							report.AuctionDuration,
+							auctionrunner.DefaultStartAuctionRules,
+						)
 
 						svgReport.DrawReportCard(i, 0, report)
 						reports = append(reports, report)
@@ -138,9 +150,21 @@ var _ = Describe("Auction", func() {
 					It("should distribute evenly", func() {
 						instances := generateUniqueLRPStartAuctions(napps[i], 1)
 
-						report := auctionDistributor.HoldAuctionsFor(instances, repGuids[:nexec[i]], auctionrunner.DefaultStartAuctionRules)
+						report := auctionDistributor.HoldAuctionsFor(
+							"Imbalanced scenario (e.g. a deploy)",
+							nexec[i],
+							instances,
+							repGuids[:nexec[i]],
+							auctionrunner.DefaultStartAuctionRules,
+						)
 
-						visualization.PrintReport(client, report.AuctionResults, repGuids[:nexec[i]], report.AuctionDuration, auctionrunner.DefaultStartAuctionRules)
+						visualization.PrintReport(
+							client,
+							report.AuctionResults,
+							repGuids[:nexec[i]],
+							report.AuctionDuration,
+							auctionrunner.DefaultStartAuctionRules,
+						)
 
 						svgReport.DrawReportCard(i, 1, report)
 						reports = append(reports, report)
@@ -166,9 +190,21 @@ var _ = Describe("Auction", func() {
 					It("should distribute evenly", func() {
 						instances := generateLRPStartAuctionsForProcessGuid(napps[i], "red", 1)
 
-						report := auctionDistributor.HoldAuctionsFor(instances, repGuids[:nexec[i]], auctionrunner.DefaultStartAuctionRules)
+						report := auctionDistributor.HoldAuctionsFor(
+							"The Watters demo",
+							nexec[i],
+							instances,
+							repGuids[:nexec[i]],
+							auctionrunner.DefaultStartAuctionRules,
+						)
 
-						visualization.PrintReport(client, report.AuctionResults, repGuids[:nexec[i]], report.AuctionDuration, auctionrunner.DefaultStartAuctionRules)
+						visualization.PrintReport(
+							client,
+							report.AuctionResults,
+							repGuids[:nexec[i]],
+							report.AuctionDuration,
+							auctionrunner.DefaultStartAuctionRules,
+						)
 
 						svgReport.DrawReportCard(i, 2, report)
 						reports = append(reports, report)

--- a/simulation/simulation_test.go
+++ b/simulation/simulation_test.go
@@ -109,11 +109,6 @@ var _ = Describe("Auction", func() {
 						instances = append(instances, generateUniqueLRPStartAuctions(n4apps[i]/2, 4)...)
 						instances = append(instances, generateLRPStartAuctionsWithRandomSVGColors(n4apps[i]/2, 4)...)
 
-						permutedInstances := make([]models.LRPStartAuction, len(instances))
-						for i, index := range util.R.Perm(len(instances)) {
-							permutedInstances[i] = instances[index]
-						}
-
 						report := auctionDistributor.HoldAuctionsFor(instances, repGuids[:nexec[i]], auctionrunner.DefaultStartAuctionRules)
 
 						visualization.PrintReport(client, report.AuctionResults, repGuids[:nexec[i]], report.AuctionDuration, auctionrunner.DefaultStartAuctionRules)

--- a/simulation/visualization/print_report.go
+++ b/simulation/visualization/print_report.go
@@ -23,7 +23,6 @@ func PrintReport(client auctiontypes.SimulationRepPoolClient, results []auctiont
 	roundsDistribution := map[int]int{}
 	auctionedInstances := map[string]bool{}
 
-	///
 	fmt.Println("Rounds Distributions")
 	for _, result := range results {
 		roundsDistribution[result.NumRounds] += 1
@@ -35,8 +34,6 @@ func PrintReport(client auctiontypes.SimulationRepPoolClient, results []auctiont
 			fmt.Printf("  %2d: %s\n", i, strings.Repeat("■", roundsDistribution[i]))
 		}
 	}
-
-	///
 
 	fmt.Println("Distribution")
 	maxGuidLength := 0
@@ -87,10 +84,8 @@ func PrintReport(client auctiontypes.SimulationRepPoolClient, results []auctiont
 	}
 	fmt.Printf("  %#v\n", rules)
 	if _, ok := client.(*inprocess.InprocessClient); ok {
-		fmt.Printf("  Latency Range: %s < %s, Timeout: %s, Flakiness: %.2f\n", inprocess.LatencyMin, inprocess.LatencyMax, inprocess.Timeout)
+		fmt.Printf("  Latency Range: %s < %s, Timeout: %s\n", inprocess.LatencyMin, inprocess.LatencyMax, inprocess.Timeout)
 	}
-
-	///
 
 	fmt.Println("Bidding Times")
 	minBiddingTime, maxBiddingTime, totalBiddingTime, meanBiddingTime := time.Hour, time.Duration(0), time.Duration(0), time.Duration(0)
@@ -123,8 +118,6 @@ func PrintReport(client auctiontypes.SimulationRepPoolClient, results []auctiont
 	meanTime = meanTime / time.Duration(len(results))
 	fmt.Printf("  Min: %s | Max: %s | Mean: %s\n", minTime, maxTime, meanTime)
 
-	///
-
 	fmt.Println("Rounds")
 	minRounds, maxRounds, totalRounds, meanRounds := 100000000, 0, 0, float64(0)
 	for _, result := range results {
@@ -141,8 +134,6 @@ func PrintReport(client auctiontypes.SimulationRepPoolClient, results []auctiont
 	meanRounds = meanRounds / float64(len(results))
 	fmt.Printf("  Min: %d | Max: %d | Total: %d | Mean: %.2f\n", minRounds, maxRounds, totalRounds, meanRounds)
 
-	///
-
 	fmt.Println("Scores")
 	minScores, maxScores, totalScores, meanScores := 100000000, 0, 0, float64(0)
 	for _, result := range results {
@@ -158,5 +149,4 @@ func PrintReport(client auctiontypes.SimulationRepPoolClient, results []auctiont
 
 	meanScores = meanScores / float64(len(results))
 	fmt.Printf("  Min: %d | Max: %d | Total: %d | Mean: %.2f\n", minScores, maxScores, totalScores, meanScores)
-
 }


### PR DESCRIPTION
Added the following statistics:
- Add stats for memory and disk usage on reps
- Add stats for how much multi-instance app colocation exceeds ideal amount of colocation

Also, improved report output and code:
- Add descriptive title for each simulation report
- Reorganize simulation report
- Refactor reports to use GoStats library for computations

Plus some minor miscellaneous cleanups.